### PR TITLE
sonarqube report and coverage tests in github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,25 +69,13 @@ jobs:
           done
           echo "SonarQube is up and running!"
 
-      - name: Install Java (Required for SonarQube)
-        run: |
-          sudo apt update
-          sudo apt install -y openjdk-17-jdk
-
-      - name: Install SonarQube Scanner
-        run: |
-          curl -o sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-5.0.1.3006-linux.zip
-          unzip sonar-scanner.zip
-          mv sonar-scanner-5.0.1.3006-linux /opt/sonar-scanner
-          echo "export PATH=$PATH:/opt/sonar-scanner/bin" >> $HOME/.bashrc
-          source $HOME/.bashrc
-
       - name: Run SonarQube Analysis
-        run: |
-          sonar-scanner \
-            -Dsonar.projectKey=SOEN390 \
-            -Dsonar.sources=. \
-            -Dsonar.host.url=http://localhost:9000 \
+        uses: sonarsource/sonarqube-scan-action@master
+        with:
+          args: >
+            -Dsonar.projectKey=SOEN390
+            -Dsonar.sources=.
+            -Dsonar.host.url=http://localhost:9000
             -Dsonar.token=${{ secrets.SONAR_TOKEN }}
 
       - name: SonarQube Report Link

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,17 +3,6 @@ name: Testing and Code Analysis
 on: [push, pull_request]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Setup Git
-        run: |
-          sudo apt-get update
-          sudo apt-get install git -y
-          git --version
 
   test_backend:
     runs-on: ubuntu-latest
@@ -64,7 +53,7 @@ jobs:
           npm run test -- --coverage
 
       - name: Upload Frontend Coverage Report
-        uses: actions/upload-artifact@v4  # ✅ Updated to v4
+        uses: actions/upload-artifact@v4
         with:
           name: frontend-coverage
           path: frontend/coverage/lcov.info
@@ -103,6 +92,22 @@ jobs:
           name: frontend-coverage
           path: frontend/coverage
 
+      - name: Print Backend Coverage Report
+        run: cat backend/coverage/lcov.info || echo "Backend coverage report not found"
+
+      - name: Print Frontend Coverage Report
+        run: cat frontend/coverage/lcov.info || echo "Frontend coverage report not found"
+
+      - name: Extract Backend Coverage Percentage
+        run: |
+          COVERAGE=$(grep -o 'lines.*' backend/coverage/lcov.info | awk '{print $NF}')
+          echo "BACKEND_COVERAGE=$COVERAGE" >> $GITHUB_ENV
+
+      - name: Extract Frontend Coverage Percentage
+        run: |
+          COVERAGE=$(grep -o 'lines.*' frontend/coverage/lcov.info | awk '{print $NF}')
+          echo "FRONTEND_COVERAGE=$COVERAGE" >> $GITHUB_ENV
+
       - name: Run SonarCloud Analysis
         run: |
           export PATH="/opt/sonar-scanner/bin:$PATH"
@@ -116,3 +121,25 @@ jobs:
 
       - name: Get SonarCloud Results
         run: "echo 'Check SonarCloud Report: https://sonarcloud.io/dashboard?id=SOEN390&branch=${GITHUB_REF##*/}'"
+
+      - name: Comment Coverage on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const coverageMessage = `
+            🚀 **Code Coverage Report** 🚀
+
+            🔹 **Backend Coverage**: \`${{ env.BACKEND_COVERAGE }}%\`
+            🔹 **Frontend Coverage**: \`${{ env.FRONTEND_COVERAGE }}%\`
+
+            _View full details in [SonarCloud Report](https://sonarcloud.io/dashboard?id=SOEN390&branch=${{ github.ref_name }})_
+            `;
+
+            github.rest.issues.createComment({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: coverageMessage
+            });

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,11 +74,12 @@ jobs:
           export PATH="/opt/sonar-scanner/bin:$PATH"
           sonar-scanner --version
 
-      - name: Run SonarQube Analysis
-        run: |
-          export PATH="/opt/sonar-scanner/bin:$PATH"
-          sonar-scanner \
-            -Dsonar.projectKey=SOEN390 \
-            -Dsonar.sources=. \
-            -Dsonar.host.url=${{ secrets.SONAR_HOST_URL }} \
-            -Dsonar.token=${{ secrets.SONAR_TOKEN }}
+          - name: Run SonarQube Analysis
+          run: |
+            export PATH="/opt/sonar-scanner/bin:$PATH"
+            sonar-scanner \
+              -Dsonar.projectKey=SOEN390 \
+              -Dsonar.sources=. \
+              -Dsonar.host.url="${{ secrets.SONAR_HOST_URL }} || (echo "SonarQube failed URL" && exit 1)" \
+              -Dsonar.token="${{ secrets.SONAR_TOKEN }}" || (echo "SonarQube failed token" && exit 1)
+  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
 
       - name: Setup Git
         run: |
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
           node-version: '20.11'
 
@@ -37,7 +37,7 @@ jobs:
           npm test -- --coverage
 
       - name: Upload Backend Coverage Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2
         with:
           name: backend-coverage
           path: backend/coverage/lcov.info
@@ -46,10 +46,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
           node-version: '22.11'
 
@@ -64,7 +64,7 @@ jobs:
           npm run test -- --coverage
 
       - name: Upload Frontend Coverage Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2
         with:
           name: frontend-coverage
           path: frontend/coverage/lcov.info
@@ -74,7 +74,7 @@ jobs:
     needs: [test_backend, test_frontend]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
 
       - name: Install Java (Required for SonarCloud)
         run: |
@@ -92,12 +92,12 @@ jobs:
           sonar-scanner --version
 
       - name: Download Coverage Reports
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v2
         with:
           name: backend-coverage
           path: backend/coverage
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v2
         with:
           name: frontend-coverage
           path: frontend/coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,13 +26,20 @@ jobs:
       - name: Run Backend Tests with Coverage
         run: |
           cd backend
-          npm test -- --coverage
+          # Run tests with coverage and output a text summary
+          npm test -- --coverage --coverageReporters=text-summary | tee coverage/coverage-summary.txt
 
       - name: Upload Backend Coverage Report
         uses: actions/upload-artifact@v4
         with:
           name: backend-coverage
           path: backend/coverage/lcov.info
+
+      - name: Upload Backend Coverage Summary
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage-summary
+          path: backend/coverage/coverage-summary.txt
 
   test_frontend:
     runs-on: ubuntu-latest
@@ -53,13 +60,20 @@ jobs:
       - name: Run Frontend Tests with Coverage
         run: |
           cd frontend
-          npm run test -- --coverage
+          # Run tests with coverage and output a text summary
+          npm run test -- --coverage --coverageReporters=text-summary | tee coverage/coverage-summary.txt
 
       - name: Upload Frontend Coverage Report
         uses: actions/upload-artifact@v4
         with:
           name: frontend-coverage
           path: frontend/coverage/lcov.info
+
+      - name: Upload Frontend Coverage Summary
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage-summary
+          path: frontend/coverage/coverage-summary.txt
 
   sonar_scan:
     runs-on: ubuntu-latest
@@ -91,27 +105,29 @@ jobs:
           name: backend-coverage
           path: backend/coverage
 
+      - name: Download Backend Coverage Summary
+        uses: actions/download-artifact@v4  
+        with:
+          name: backend-coverage-summary
+          path: backend/coverage
+
       - name: Download Frontend Coverage Report
         uses: actions/download-artifact@v4  
         with:
           name: frontend-coverage
           path: frontend/coverage
 
-      - name: Print Backend Coverage Report
-        run: cat backend/coverage/lcov.info || echo "Backend coverage report not found"
+      - name: Download Frontend Coverage Summary
+        uses: actions/download-artifact@v4  
+        with:
+          name: frontend-coverage-summary
+          path: frontend/coverage
 
-      - name: Print Frontend Coverage Report
-        run: cat frontend/coverage/lcov.info || echo "Frontend coverage report not found"
+      - name: Print Backend Coverage Summary
+        run: cat backend/coverage/coverage-summary.txt || echo "Backend coverage summary not found"
 
-      - name: Extract Backend Coverage Percentage
-        run: |
-          COVERAGE=$(grep -o 'lines.*' backend/coverage/lcov.info | awk '{print $NF}')
-          echo "BACKEND_COVERAGE=$COVERAGE" >> $GITHUB_ENV
-
-      - name: Extract Frontend Coverage Percentage
-        run: |
-          COVERAGE=$(grep -o 'lines.*' frontend/coverage/lcov.info | awk '{print $NF}')
-          echo "FRONTEND_COVERAGE=$COVERAGE" >> $GITHUB_ENV
+      - name: Print Frontend Coverage Summary
+        run: cat frontend/coverage/coverage-summary.txt || echo "Frontend coverage summary not found"
 
       - name: Run SonarCloud Analysis
         run: |
@@ -124,26 +140,37 @@ jobs:
             -Dsonar.token=${{ secrets.SONAR_TOKEN }} \
             -Dsonar.javascript.lcov.reportPaths=backend/coverage/lcov.info,frontend/coverage/lcov.info || (echo "SonarCloud analysis failed" && exit 1)
 
-      - name: Get SonarCloud Results
-        run: "echo 'Check SonarCloud Report: https://sonarcloud.io/dashboard?id=Andrew-Dagher_SOEN-390&branch=${GITHUB_REF##*/}'"
-
       - name: Comment Coverage on PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const fs = require('fs');
+            let backendCoverage = 'Backend coverage summary not found';
+            let frontendCoverage = 'Frontend coverage summary not found';
+            try {
+              backendCoverage = fs.readFileSync('backend/coverage/coverage-summary.txt', 'utf8');
+            } catch (error) {}
+            try {
+              frontendCoverage = fs.readFileSync('frontend/coverage/coverage-summary.txt', 'utf8');
+            } catch (error) {}
             const coverageMessage = `
             🚀 **Code Coverage Report** 🚀
 
-            🔹 **Backend Coverage**: \`${{ env.BACKEND_COVERAGE }}%\`
-            🔹 **Frontend Coverage**: \`${{ env.FRONTEND_COVERAGE }}%\`
+            **Backend Coverage Summary:**
+            \`\`\`
+            ${backendCoverage}
+            \`\`\`
 
-            _View full details in [SonarCloud Report](https://sonarcloud.io/dashboard?id=Andrew-Dagher_SOEN-390&branch=${{ github.ref_name }})_
-            `;
-            github.rest.issues.createComment({
-              issue_number: context.payload.pull_request.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: coverageMessage
-            });
+            **Frontend Coverage Summary:**
+            \`\`\`
+            ${frontendCoverage}
+            \`\`\`
+                        `;
+                        github.rest.issues.createComment({
+                          issue_number: context.payload.pull_request.number,
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          body: coverageMessage
+                        });

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,9 @@
 name: Testing and Code Analysis
 
-on: 
+on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:
@@ -9,74 +11,67 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
-        with: 
-          node-version: 20.11
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.11'
+
       - name: Install Backend Dependencies
         run: |
           cd backend
           npm ci
+
       - name: Run Backend Tests with Coverage
         run: |
           cd backend
-          npm test -- --coverage # Shows coverage in console
+          npm test -- --coverage
 
   test_frontend:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with: 
-          node-version: 22.11
-      - name: Clear npm cache
-        run: npm cache clean --force
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22.11'
+
       - name: Install Frontend Dependencies
         run: |
           cd frontend
           npm install
+
       - name: Run Frontend Tests with Coverage
         run: |
           cd frontend
-          npm run test -- --coverage # Shows coverage in console
+          npm run test -- --coverage
 
   sonar_scan:
     runs-on: ubuntu-latest
     needs: [test_backend, test_frontend]
 
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
-      
-      - name: Start SonarQube in Docker
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up SonarQube Scanner
         run: |
-          docker run -d --name sonar \
-            -p 9000:9000 \
-            -e SONAR_ES_BOOTSTRAP_CHECKS_DISABLE=true \
-            sonarqube:lts
-      
-      - name: Wait for SonarQube to be ready
-        run: |
-          echo "Waiting for SonarQube to be ready..."
-          until curl -s http://localhost:9000/api/system/status | grep -q "UP"; do
-            sleep 5
-            echo "Waiting..."
-          done
-          echo "SonarQube is up and running!"
+          wget -O sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.7.0.2747-linux.zip
+          unzip sonar-scanner.zip
+          export PATH="$PATH:$(pwd)/sonar-scanner-4.7.0.2747-linux/bin"
 
       - name: Run SonarQube Analysis
-        uses: sonarsource/sonarqube-scan-action@master
-        with:
-          args: >
-            -Dsonar.projectKey=SOEN390
-            -Dsonar.sources=.
-            -Dsonar.host.url=http://localhost:9000
-            -Dsonar.token=${{ secrets.SONAR_TOKEN }}
-
-      - name: SonarQube Report Link
-        run: echo "Check SonarQube results at http://localhost:9000/dashboard?id=SOEN390"
+        env:
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          sonar-scanner \
+            -Dsonar.projectKey=SOEN390 \
+            -Dsonar.sources=. \
+            -Dsonar.host.url=$SONAR_HOST_URL \
+            -Dsonar.login=$SONAR_TOKEN

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Run Backend Tests with Coverage
         run: |
           cd backend
+          mkdir -p coverage
           # Run tests with coverage and output a text summary
           npm test -- --coverage --coverageReporters=text-summary | tee coverage/coverage-summary.txt
 
@@ -60,6 +61,7 @@ jobs:
       - name: Run Frontend Tests with Coverage
         run: |
           cd frontend
+          mkdir -p coverage
           # Run tests with coverage and output a text summary
           npm run test -- --coverage --coverageReporters=text-summary | tee coverage/coverage-summary.txt
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,17 +28,43 @@ jobs:
           cd backend
           npm test -- --coverage | tee coverage_summary.txt
 
+      - name: Upload Backend Coverage Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: backend/coverage/lcov.info
+
       - name: Upload Backend Coverage Summary
         uses: actions/upload-artifact@v4
         with:
           name: backend-coverage-summary
           path: backend/coverage_summary.txt
 
-      - name: Upload Backend Coverage Report
-        uses: actions/upload-artifact@v4
+      - name: Comment Backend Coverage on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v6
         with:
-          name: backend-coverage-report
-          path: backend/coverage/lcov.info
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const summaryPath = 'backend/coverage_summary.txt';
+            let summary = 'Coverage summary not found.';
+            if (fs.existsSync(summaryPath)) {
+              summary = fs.readFileSync(summaryPath, 'utf8');
+            }
+            const message = `
+            🚀 **Backend Code Coverage Report** 🚀
+
+            \`\`\`
+            ${summary}
+            \`\`\`
+                        `;
+                        github.rest.issues.createComment({
+                          issue_number: context.payload.pull_request.number,
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          body: message
+                        });
 
   test_frontend:
     runs-on: ubuntu-latest
@@ -61,18 +87,43 @@ jobs:
           cd frontend
           npm run test -- --coverage | tee coverage_summary.txt
 
+      - name: Upload Frontend Coverage Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage
+          path: frontend/coverage/lcov.info
+
       - name: Upload Frontend Coverage Summary
         uses: actions/upload-artifact@v4
         with:
           name: frontend-coverage-summary
           path: frontend/coverage_summary.txt
 
-      - name: Upload Frontend Coverage Report
-        uses: actions/upload-artifact@v4
+      - name: Comment Frontend Coverage on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v6
         with:
-          name: frontend-coverage-report
-          path: frontend/coverage/lcov.info
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const summaryPath = 'frontend/coverage_summary.txt';
+            let summary = 'Coverage summary not found.';
+            if (fs.existsSync(summaryPath)) {
+              summary = fs.readFileSync(summaryPath, 'utf8');
+            }
+            const message = `
+            🚀 **Frontend Code Coverage Report** 🚀
 
+            \`\`\`
+            ${summary}
+            \`\`\`
+                        `;
+                        github.rest.issues.createComment({
+                          issue_number: context.payload.pull_request.number,
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          body: message
+                        });
   sonar_scan:
     runs-on: ubuntu-latest
     needs: [test_backend, test_frontend]
@@ -97,28 +148,16 @@ jobs:
           export PATH="/opt/sonar-scanner/bin:$PATH"
           sonar-scanner --version
 
-      - name: Download Backend Artifacts
-        uses: actions/download-artifact@v4  
-        with:
-          name: backend-coverage-summary
-          path: backend
-          
-      - name: Download Frontend Artifacts
-        uses: actions/download-artifact@v4  
-        with:
-          name: frontend-coverage-summary
-          path: frontend
-
       - name: Download Backend Coverage Report
         uses: actions/download-artifact@v4  
         with:
-          name: backend-coverage-report
+          name: backend-coverage
           path: backend/coverage
 
       - name: Download Frontend Coverage Report
         uses: actions/download-artifact@v4  
         with:
-          name: frontend-coverage-report
+          name: frontend-coverage
           path: frontend/coverage
 
       - name: Print Backend Coverage Report
@@ -126,20 +165,6 @@ jobs:
 
       - name: Print Frontend Coverage Report
         run: cat frontend/coverage/lcov.info || echo "Frontend coverage report not found"
-
-      - name: Get Backend Coverage Summary
-        id: backend_cov
-        run: |
-          echo "backend_summary<<EOF" >> $GITHUB_OUTPUT
-          cat backend/coverage_summary.txt
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Get Frontend Coverage Summary
-        id: frontend_cov
-        run: |
-          echo "frontend_summary<<EOF" >> $GITHUB_OUTPUT
-          cat frontend/coverage_summary.txt
-          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Run SonarCloud Analysis
         run: |
@@ -154,29 +179,3 @@ jobs:
 
       - name: Get SonarCloud Results
         run: "echo 'Check SonarCloud Report: https://sonarcloud.io/dashboard?id=Andrew-Dagher_SOEN-390&branch=${GITHUB_REF##*/}'"
-
-      - name: Comment Coverage on PR
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const backendSummary = `\n${{ steps.backend_cov.outputs.backend_summary }}`;
-            const frontendSummary = `\n${{ steps.frontend_cov.outputs.frontend_summary }}`;
-            const coverageMessage = `
-            🚀 **Code Coverage Report** 🚀
-
-            **Backend Coverage Summary:**
-            ${backendSummary}
-
-            **Frontend Coverage Summary:**
-            ${frontendSummary}
-
-            Coverage details are provided above as plain text.
-                        `;
-                        github.rest.issues.createComment({
-                          issue_number: context.payload.pull_request.number,
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          body: coverageMessage
-                        });

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout Code
         uses: actions/checkout@v2
-      - name: Setup Node
+      - name: Setup Node.js
         uses: actions/setup-node@v2
         with: 
           node-version: 20.11
@@ -22,21 +22,15 @@ jobs:
       - name: Run Backend Tests with Coverage
         run: |
           cd backend
-          npm test -- --coverage
-      - name: Upload Jest Coverage Report to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          files: backend/coverage/lcov.info
-          flags: backend
-          fail_ci_if_error: true
+          npm test -- --coverage # Shows coverage in console
 
   test_frontend:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout Code
         uses: actions/checkout@v2
-      - name: Setup Node
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with: 
           node-version: 22.11
@@ -49,20 +43,14 @@ jobs:
       - name: Run Frontend Tests with Coverage
         run: |
           cd frontend
-          npm run test -- --coverage
-      - name: Upload Jest Coverage Report to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          files: frontend/coverage/lcov.info
-          flags: frontend
-          fail_ci_if_error: true
+          npm run test -- --coverage # Shows coverage in console
 
   sonar_scan:
     runs-on: macos-latest
     needs: [test_backend, test_frontend]
 
     steps:
-      - name: Checkout
+      - name: Checkout Code
         uses: actions/checkout@v2
       - name: Install Java (Required for SonarQube)
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,12 +68,15 @@ jobs:
         run: |
           curl -o sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-5.0.1.3006-linux.zip
           unzip sonar-scanner.zip
-          mv sonar-scanner-5.0.1.3006-linux /opt/sonar-scanner
-          echo "export PATH=$PATH:/opt/sonar-scanner/bin" >> $HOME/.bashrc
+          sudo mv sonar-scanner-5.0.1.3006-linux /opt/sonar-scanner
+          echo "export PATH=/opt/sonar-scanner/bin:$PATH" >> $HOME/.bashrc
           source $HOME/.bashrc
+          export PATH="/opt/sonar-scanner/bin:$PATH"
+          sonar-scanner --version
 
       - name: Run SonarQube Analysis
         run: |
+          export PATH="/opt/sonar-scanner/bin:$PATH"
           sonar-scanner \
             -Dsonar.projectKey=SOEN390 \
             -Dsonar.sources=. \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,7 @@ jobs:
           export PATH="/opt/sonar-scanner/bin:$PATH"
           sonar-scanner \
             -Dsonar.organization=${{ secrets.SONAR_ORG }} \
-            -Dsonar.projectKey=SOEN390 \
+            -Dsonar.projectKey=SOEN-390 \
             -Dsonar.sources=. \
             -Dsonar.host.url=${{ secrets.SONAR_HOST_URL }} \
             -Dsonar.token=${{ secrets.SONAR_TOKEN }} \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,28 +2,22 @@ name: Testing and Code Analysis
 
 on:
   push:
-    branches:
-      - main
   pull_request:
 
 jobs:
   test_backend:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Set up Node.js
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: '20.11'
-
       - name: Install Backend Dependencies
         run: |
           cd backend
           npm ci
-
       - name: Run Backend Tests with Coverage
         run: |
           cd backend
@@ -31,21 +25,17 @@ jobs:
 
   test_frontend:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Set up Node.js
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: '22.11'
-
       - name: Install Frontend Dependencies
         run: |
           cd frontend
           npm install
-
       - name: Run Frontend Tests with Coverage
         run: |
           cd frontend
@@ -54,24 +44,14 @@ jobs:
   sonar_scan:
     runs-on: ubuntu-latest
     needs: [test_backend, test_frontend]
-
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Set up SonarQube Scanner
-        run: |
-          wget -O sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.7.0.2747-linux.zip
-          unzip sonar-scanner.zip
-          export PATH="$PATH:$(pwd)/sonar-scanner-4.7.0.2747-linux/bin"
-
-      - name: Run SonarQube Analysis
-        env:
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: |
-          sonar-scanner \
-            -Dsonar.projectKey=SOEN390 \
-            -Dsonar.sources=. \
-            -Dsonar.host.url=$SONAR_HOST_URL \
-            -Dsonar.login=$SONAR_TOKEN
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v4.1.0
+        with:
+          args: >
+            -Dsonar.projectKey=SOEN390
+            -Dsonar.sources=.
+            -Dsonar.host.url=${{ secrets.SONAR_HOST_URL }}
+            -Dsonar.login=${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,21 +46,42 @@ jobs:
           npm run test -- --coverage # Shows coverage in console
 
   sonar_scan:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: [test_backend, test_frontend]
 
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
+      
+      - name: Start SonarQube in Docker
+        run: |
+          docker run -d --name sonar \
+            -p 9000:9000 \
+            -e SONAR_ES_BOOTSTRAP_CHECKS_DISABLE=true \
+            sonarqube:lts
+      
+      - name: Wait for SonarQube to be ready
+        run: |
+          echo "Waiting for SonarQube to be ready..."
+          until curl -s http://localhost:9000/api/system/status | grep -q "UP"; do
+            sleep 5
+            echo "Waiting..."
+          done
+          echo "SonarQube is up and running!"
+
       - name: Install Java (Required for SonarQube)
         run: |
-          brew install openjdk
-          echo "export JAVA_HOME=$(/usr/libexec/java_home)" >> $HOME/.zshrc
-          source $HOME/.zshrc
+          sudo apt update
+          sudo apt install -y openjdk-17-jdk
+
       - name: Install SonarQube Scanner
         run: |
-          brew install sonarqube
-          brew install sonar-scanner
+          curl -o sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-5.0.1.3006-linux.zip
+          unzip sonar-scanner.zip
+          mv sonar-scanner-5.0.1.3006-linux /opt/sonar-scanner
+          echo "export PATH=$PATH:/opt/sonar-scanner/bin" >> $HOME/.bashrc
+          source $HOME/.bashrc
+
       - name: Run SonarQube Analysis
         run: |
           sonar-scanner \
@@ -68,5 +89,6 @@ jobs:
             -Dsonar.sources=. \
             -Dsonar.host.url=http://localhost:9000 \
             -Dsonar.token=${{ secrets.SONAR_TOKEN }}
+
       - name: SonarQube Report Link
         run: echo "Check SonarQube results at http://localhost:9000/dashboard?id=SOEN390"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,21 @@
 name: Testing and Code Analysis
 
-on:
-  push:
-  pull_request:
+on: [push, pull_request]
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Setup Git
+      run: |
+        sudo apt-get update
+        sudo apt-get install git -y
+        git --version
+        
   test_backend:
     runs-on: ubuntu-latest
     steps:
@@ -45,13 +56,26 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test_backend, test_frontend]
     steps:
-      - name: Checkout
+      - name: Checkout Code
         uses: actions/checkout@v3
-      - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v4.1.0
-        with:
-          args: >
-            -Dsonar.projectKey=SOEN390
-            -Dsonar.sources=.
-            -Dsonar.host.url=${{ secrets.SONAR_HOST_URL }}
-            -Dsonar.login=${{ secrets.SONAR_TOKEN }}
+
+      - name: Install Java (Required for SonarQube)
+        run: |
+          sudo apt update
+          sudo apt install -y openjdk-17-jdk
+
+      - name: Install SonarQube Scanner
+        run: |
+          curl -o sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-5.0.1.3006-linux.zip
+          unzip sonar-scanner.zip
+          mv sonar-scanner-5.0.1.3006-linux /opt/sonar-scanner
+          echo "export PATH=$PATH:/opt/sonar-scanner/bin" >> $HOME/.bashrc
+          source $HOME/.bashrc
+
+      - name: Run SonarQube Analysis
+        run: |
+          sonar-scanner \
+            -Dsonar.projectKey=SOEN390 \
+            -Dsonar.sources=. \
+            -Dsonar.host.url=${{ secrets.SONAR_HOST_URL }} \
+            -Dsonar.token=${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
           npm run test -- --coverage
 
       - name: Upload Frontend Coverage Report
-        uses: actions/upload-artifact@v4  # ✅ Updated to v4
+        uses: actions/upload-artifact@v4 
         with:
           name: frontend-coverage
           path: frontend/coverage/lcov.info
@@ -74,45 +74,16 @@ jobs:
     needs: [test_backend, test_frontend]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Install Java (Required for SonarCloud)
-        run: |
-          sudo apt update
-          sudo apt install -y openjdk-17-jdk
-
-      - name: Install SonarQube Scanner
-        run: |
-          curl -o sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-5.0.1.3006-linux.zip
-          unzip sonar-scanner.zip
-          sudo mv sonar-scanner-5.0.1.3006-linux /opt/sonar-scanner
-          echo "export PATH=/opt/sonar-scanner/bin:$PATH" >> $HOME/.bashrc
-          source $HOME/.bashrc
-          export PATH="/opt/sonar-scanner/bin:$PATH"
-          sonar-scanner --version
-
-      - name: Download Backend Coverage Report
-        uses: actions/download-artifact@v4  # ✅ Updated to v4
+        uses: actions/checkout@v4
         with:
-          name: backend-coverage
-          path: backend/coverage
+          fetch-depth: 0  # Ensures full clone for accurate analysis
 
-      - name: Download Frontend Coverage Report
-        uses: actions/download-artifact@v4  # ✅ Updated to v4
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v4
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
-          name: frontend-coverage
-          path: frontend/coverage
-
-      - name: Run SonarCloud Analysis
-        run: |
-          export PATH="/opt/sonar-scanner/bin:$PATH"
-          sonar-scanner \
-            -Dsonar.organization=${{ secrets.SONAR_ORG }} \
-            -Dsonar.projectKey=Andrew-Dagher_SOEN-390 \
-            -Dsonar.sources=. \
-            -Dsonar.host.url=${{ secrets.SONAR_HOST_URL }} \
-            -Dsonar.token=${{ secrets.SONAR_TOKEN }} \
-            -Dsonar.javascript.lcov.reportPaths=backend/coverage/lcov.info,frontend/coverage/lcov.info || (echo "SonarCloud analysis failed" && exit 1)
-
-      - name: Get SonarCloud Results
-        run: "echo 'Check SonarCloud Report: https://sonarcloud.io/dashboard?id=SOEN390&branch=${GITHUB_REF##*/}'"
+          args: >
+            -Dsonar.organization=${{ secrets.SONAR_ORG }}
+            -Dsonar.projectKey=${{ secrets.SONAR_PROJECT_KEY }}
+            -Dsonar.host.url=https://sonarcloud.io

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Testing
+name: Testing and Code Analysis
 
 on: 
   push:
@@ -19,10 +19,16 @@ jobs:
         run: |
           cd backend
           npm ci
-      - name: Run Backend Tests
+      - name: Run Backend Tests with Coverage
         run: |
           cd backend
-          npm test
+          npm test -- --coverage
+      - name: Upload Jest Coverage Report to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: backend/coverage/lcov.info
+          flags: backend
+          fail_ci_if_error: true
 
   test_frontend:
     runs-on: ubuntu-latest
@@ -40,7 +46,39 @@ jobs:
         run: |
           cd frontend
           npm install
-      - name: Run Frontend Tests
+      - name: Run Frontend Tests with Coverage
         run: |
           cd frontend
-          npm run test
+          npm run test -- --coverage
+      - name: Upload Jest Coverage Report to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: frontend/coverage/lcov.info
+          flags: frontend
+          fail_ci_if_error: true
+
+  sonar_scan:
+    runs-on: macos-latest
+    needs: [test_backend, test_frontend]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Java (Required for SonarQube)
+        run: |
+          brew install openjdk
+          echo "export JAVA_HOME=$(/usr/libexec/java_home)" >> $HOME/.zshrc
+          source $HOME/.zshrc
+      - name: Install SonarQube Scanner
+        run: |
+          brew install sonarqube
+          brew install sonar-scanner
+      - name: Run SonarQube Analysis
+        run: |
+          sonar-scanner \
+            -Dsonar.projectKey=SOEN390 \
+            -Dsonar.sources=. \
+            -Dsonar.host.url=http://localhost:9000 \
+            -Dsonar.token=${{ secrets.SONAR_TOKEN }}
+      - name: SonarQube Report Link
+        run: echo "Check SonarQube results at http://localhost:9000/dashboard?id=SOEN390"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,7 +124,7 @@ jobs:
             -Dsonar.javascript.lcov.reportPaths=backend/coverage/lcov.info,frontend/coverage/lcov.info || (echo "SonarCloud analysis failed" && exit 1)
 
       - name: Get SonarCloud Results
-        run: "echo 'Check SonarCloud Report: https://sonarcloud.io/dashboard?id=SOEN390&branch=${GITHUB_REF##*/}'"
+        run: "echo 'Check SonarCloud Report: https://sonarcloud.io/dashboard?id=Andrew-Dagher_SOEN-390&branch=${GITHUB_REF##*/}'"
 
       - name: Comment Coverage on PR
         if: github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
           npm run test -- --coverage
 
       - name: Upload Frontend Coverage Report
-        uses: actions/upload-artifact@v4 
+        uses: actions/upload-artifact@v4
         with:
           name: frontend-coverage
           path: frontend/coverage/lcov.info
@@ -74,16 +74,61 @@ jobs:
     needs: [test_backend, test_frontend]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Ensures full clone for accurate analysis
+        uses: actions/checkout@v3
 
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v4
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - name: Install Java (Required for SonarCloud)
+        run: |
+          sudo apt update
+          sudo apt install -y openjdk-17-jdk
+
+      - name: Install SonarQube Scanner
+        run: |
+          curl -o sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-5.0.1.3006-linux.zip
+          unzip sonar-scanner.zip
+          sudo mv sonar-scanner-5.0.1.3006-linux /opt/sonar-scanner
+          echo "export PATH=/opt/sonar-scanner/bin:$PATH" >> $HOME/.bashrc
+          source $HOME/.bashrc
+          export PATH="/opt/sonar-scanner/bin:$PATH"
+          sonar-scanner --version
+
+      - name: Download Backend Coverage Report
+        uses: actions/download-artifact@v4  
         with:
-          args: >
-            -Dsonar.organization=${{ secrets.SONAR_ORG }}
-            -Dsonar.projectKey=${{ secrets.SONAR_PROJECT_KEY }}
-            -Dsonar.host.url=https://sonarcloud.io
+          name: backend-coverage
+          path: backend/coverage
+
+      - name: Download Frontend Coverage Report
+        uses: actions/download-artifact@v4  
+        with:
+          name: frontend-coverage
+          path: frontend/coverage
+
+      - name: List Artifacts (Debugging Step)
+        run: |
+          echo "Backend Coverage Report:"
+          ls -lh backend/coverage
+          echo "Frontend Coverage Report:"
+          ls -lh frontend/coverage
+
+      - name: Run SonarCloud Analysis
+        run: |
+          export PATH="/opt/sonar-scanner/bin:$PATH"
+          sonar-scanner \
+            -Dsonar.organization=${{ secrets.SONAR_ORG }} \
+            -Dsonar.projectKey=Andrew-Dagher_SOEN-390 \
+            -Dsonar.sources=. \
+            -Dsonar.host.url=${{ secrets.SONAR_HOST_URL }} \
+            -Dsonar.token=${{ secrets.SONAR_TOKEN }} \
+            -Dsonar.javascript.lcov.reportPaths=backend/coverage/lcov.info,frontend/coverage/lcov.info || (echo "SonarCloud analysis failed" && exit 1)
+
+      - name: Get SonarCloud Results
+        run: |
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}
+          SONAR_URL="https://sonarcloud.io/dashboard?id=SOEN390&branch=${BRANCH_NAME}"
+          echo "Check SonarCloud Report: ${SONAR_URL}"
+
+      - name: Comment on PR with SonarCloud Report
+        if: github.event_name == 'pull_request'
+        uses: mshick/add-pr-comment@v2
+        with:
+          message: "🚀 **SonarCloud Report Available**: [View it here](https://sonarcloud.io/dashboard?id=SOEN390&branch=${GITHUB_REF#refs/heads/})"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
           npm run test -- --coverage
 
       - name: Upload Frontend Coverage Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4  # ✅ Updated to v4
         with:
           name: frontend-coverage
           path: frontend/coverage/lcov.info
@@ -103,13 +103,6 @@ jobs:
           name: frontend-coverage
           path: frontend/coverage
 
-      - name: List Artifacts (Debugging Step)
-        run: |
-          echo "Backend Coverage Report:"
-          ls -lh backend/coverage
-          echo "Frontend Coverage Report:"
-          ls -lh frontend/coverage
-
       - name: Run SonarCloud Analysis
         run: |
           export PATH="/opt/sonar-scanner/bin:$PATH"
@@ -122,13 +115,4 @@ jobs:
             -Dsonar.javascript.lcov.reportPaths=backend/coverage/lcov.info,frontend/coverage/lcov.info || (echo "SonarCloud analysis failed" && exit 1)
 
       - name: Get SonarCloud Results
-        run: |
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          SONAR_URL="https://sonarcloud.io/dashboard?id=SOEN390&branch=${BRANCH_NAME}"
-          echo "Check SonarCloud Report: ${SONAR_URL}"
-
-      - name: Comment on PR with SonarCloud Report
-        if: github.event_name == 'pull_request'
-        uses: mshick/add-pr-comment@v2
-        with:
-          message: "🚀 **SonarCloud Report Available**: [View it here](https://sonarcloud.io/dashboard?id=SOEN390&branch=${GITHUB_REF#refs/heads/})"
+        run: "echo 'Check SonarCloud Report: https://sonarcloud.io/dashboard?id=SOEN390&branch=${GITHUB_REF##*/}'"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,15 +23,21 @@ jobs:
           cd backend
           npm ci
 
-      - name: Run Backend Tests with Coverage
+      - name: Run Backend Tests with Coverage and Save Summary
         run: |
           cd backend
-          npm test -- --coverage
+          npm test -- --coverage | tee coverage_summary.txt
+
+      - name: Upload Backend Coverage Summary
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage-summary
+          path: backend/coverage_summary.txt
 
       - name: Upload Backend Coverage Report
         uses: actions/upload-artifact@v4
         with:
-          name: backend-coverage
+          name: backend-coverage-report
           path: backend/coverage/lcov.info
 
   test_frontend:
@@ -50,15 +56,21 @@ jobs:
           cd frontend
           npm install
 
-      - name: Run Frontend Tests with Coverage
+      - name: Run Frontend Tests with Coverage and Save Summary
         run: |
           cd frontend
-          npm run test -- --coverage
+          npm run test -- --coverage | tee coverage_summary.txt
+
+      - name: Upload Frontend Coverage Summary
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage-summary
+          path: frontend/coverage_summary.txt
 
       - name: Upload Frontend Coverage Report
         uses: actions/upload-artifact@v4
         with:
-          name: frontend-coverage
+          name: frontend-coverage-report
           path: frontend/coverage/lcov.info
 
   sonar_scan:
@@ -85,16 +97,28 @@ jobs:
           export PATH="/opt/sonar-scanner/bin:$PATH"
           sonar-scanner --version
 
+      - name: Download Backend Artifacts
+        uses: actions/download-artifact@v4  
+        with:
+          name: backend-coverage-summary
+          path: backend
+          
+      - name: Download Frontend Artifacts
+        uses: actions/download-artifact@v4  
+        with:
+          name: frontend-coverage-summary
+          path: frontend
+
       - name: Download Backend Coverage Report
         uses: actions/download-artifact@v4  
         with:
-          name: backend-coverage
+          name: backend-coverage-report
           path: backend/coverage
 
       - name: Download Frontend Coverage Report
         uses: actions/download-artifact@v4  
         with:
-          name: frontend-coverage
+          name: frontend-coverage-report
           path: frontend/coverage
 
       - name: Print Backend Coverage Report
@@ -103,15 +127,19 @@ jobs:
       - name: Print Frontend Coverage Report
         run: cat frontend/coverage/lcov.info || echo "Frontend coverage report not found"
 
-      - name: Extract Backend Coverage Percentage
+      - name: Get Backend Coverage Summary
+        id: backend_cov
         run: |
-          COVERAGE=$(grep -o 'lines.*' backend/coverage/lcov.info | awk '{print $NF}')
-          echo "BACKEND_COVERAGE=$COVERAGE" >> $GITHUB_ENV
+          echo "backend_summary<<EOF" >> $GITHUB_OUTPUT
+          cat backend/coverage_summary.txt
+          echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Extract Frontend Coverage Percentage
+      - name: Get Frontend Coverage Summary
+        id: frontend_cov
         run: |
-          COVERAGE=$(grep -o 'lines.*' frontend/coverage/lcov.info | awk '{print $NF}')
-          echo "FRONTEND_COVERAGE=$COVERAGE" >> $GITHUB_ENV
+          echo "frontend_summary<<EOF" >> $GITHUB_OUTPUT
+          cat frontend/coverage_summary.txt
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Run SonarCloud Analysis
         run: |
@@ -133,17 +161,22 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const backendSummary = `\n${{ steps.backend_cov.outputs.backend_summary }}`;
+            const frontendSummary = `\n${{ steps.frontend_cov.outputs.frontend_summary }}`;
             const coverageMessage = `
             🚀 **Code Coverage Report** 🚀
 
-            🔹 **Backend Coverage**: \`${{ env.BACKEND_COVERAGE }}%\`
-            🔹 **Frontend Coverage**: \`${{ env.FRONTEND_COVERAGE }}%\`
+            **Backend Coverage Summary:**
+            ${backendSummary}
 
-            _Coverage details are provided above as plain text._
-            `;
-            github.rest.issues.createComment({
-              issue_number: context.payload.pull_request.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: coverageMessage
-            });
+            **Frontend Coverage Summary:**
+            ${frontendSummary}
+
+            Coverage details are provided above as plain text.
+                        `;
+                        github.rest.issues.createComment({
+                          issue_number: context.payload.pull_request.number,
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          body: coverageMessage
+                        });

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,21 +26,13 @@ jobs:
       - name: Run Backend Tests with Coverage
         run: |
           cd backend
-          mkdir -p coverage
-          # Run tests with coverage and output a text summary
-          npm test -- --coverage --coverageReporters=text-summary | tee coverage/coverage-summary.txt
+          npm test -- --coverage
 
       - name: Upload Backend Coverage Report
         uses: actions/upload-artifact@v4
         with:
           name: backend-coverage
           path: backend/coverage/lcov.info
-
-      - name: Upload Backend Coverage Summary
-        uses: actions/upload-artifact@v4
-        with:
-          name: backend-coverage-summary
-          path: backend/coverage/coverage-summary.txt
 
   test_frontend:
     runs-on: ubuntu-latest
@@ -61,21 +53,13 @@ jobs:
       - name: Run Frontend Tests with Coverage
         run: |
           cd frontend
-          mkdir -p coverage
-          # Run tests with coverage and output a text summary
-          npm run test -- --coverage --coverageReporters=text-summary | tee coverage/coverage-summary.txt
+          npm run test -- --coverage
 
       - name: Upload Frontend Coverage Report
         uses: actions/upload-artifact@v4
         with:
           name: frontend-coverage
           path: frontend/coverage/lcov.info
-
-      - name: Upload Frontend Coverage Summary
-        uses: actions/upload-artifact@v4
-        with:
-          name: frontend-coverage-summary
-          path: frontend/coverage/coverage-summary.txt
 
   sonar_scan:
     runs-on: ubuntu-latest
@@ -107,29 +91,27 @@ jobs:
           name: backend-coverage
           path: backend/coverage
 
-      - name: Download Backend Coverage Summary
-        uses: actions/download-artifact@v4  
-        with:
-          name: backend-coverage-summary
-          path: backend/coverage
-
       - name: Download Frontend Coverage Report
         uses: actions/download-artifact@v4  
         with:
           name: frontend-coverage
           path: frontend/coverage
 
-      - name: Download Frontend Coverage Summary
-        uses: actions/download-artifact@v4  
-        with:
-          name: frontend-coverage-summary
-          path: frontend/coverage
+      - name: Print Backend Coverage Report
+        run: cat backend/coverage/lcov.info || echo "Backend coverage report not found"
 
-      - name: Print Backend Coverage Summary
-        run: cat backend/coverage/coverage-summary.txt || echo "Backend coverage summary not found"
+      - name: Print Frontend Coverage Report
+        run: cat frontend/coverage/lcov.info || echo "Frontend coverage report not found"
 
-      - name: Print Frontend Coverage Summary
-        run: cat frontend/coverage/coverage-summary.txt || echo "Frontend coverage summary not found"
+      - name: Extract Backend Coverage Percentage
+        run: |
+          COVERAGE=$(grep -o 'lines.*' backend/coverage/lcov.info | awk '{print $NF}')
+          echo "BACKEND_COVERAGE=$COVERAGE" >> $GITHUB_ENV
+
+      - name: Extract Frontend Coverage Percentage
+        run: |
+          COVERAGE=$(grep -o 'lines.*' frontend/coverage/lcov.info | awk '{print $NF}')
+          echo "FRONTEND_COVERAGE=$COVERAGE" >> $GITHUB_ENV
 
       - name: Run SonarCloud Analysis
         run: |
@@ -142,37 +124,26 @@ jobs:
             -Dsonar.token=${{ secrets.SONAR_TOKEN }} \
             -Dsonar.javascript.lcov.reportPaths=backend/coverage/lcov.info,frontend/coverage/lcov.info || (echo "SonarCloud analysis failed" && exit 1)
 
+      - name: Get SonarCloud Results
+        run: "echo 'Check SonarCloud Report: https://sonarcloud.io/dashboard?id=Andrew-Dagher_SOEN-390&branch=${GITHUB_REF##*/}'"
+
       - name: Comment Coverage on PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const fs = require('fs');
-            let backendCoverage = 'Backend coverage summary not found';
-            let frontendCoverage = 'Frontend coverage summary not found';
-            try {
-              backendCoverage = fs.readFileSync('backend/coverage/coverage-summary.txt', 'utf8');
-            } catch (error) {}
-            try {
-              frontendCoverage = fs.readFileSync('frontend/coverage/coverage-summary.txt', 'utf8');
-            } catch (error) {}
             const coverageMessage = `
             🚀 **Code Coverage Report** 🚀
 
-            **Backend Coverage Summary:**
-            \`\`\`
-            ${backendCoverage}
-            \`\`\`
+            🔹 **Backend Coverage**: \`${{ env.BACKEND_COVERAGE }}%\`
+            🔹 **Frontend Coverage**: \`${{ env.FRONTEND_COVERAGE }}%\`
 
-            **Frontend Coverage Summary:**
-            \`\`\`
-            ${frontendCoverage}
-            \`\`\`
-                        `;
-                        github.rest.issues.createComment({
-                          issue_number: context.payload.pull_request.number,
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          body: coverageMessage
-                        });
+            _Coverage details are provided above as plain text._
+            `;
+            github.rest.issues.createComment({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: coverageMessage
+            });

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,52 +5,69 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: Setup Git
-      run: |
-        sudo apt-get update
-        sudo apt-get install git -y
-        git --version
-        
+      - name: Setup Git
+        run: |
+          sudo apt-get update
+          sudo apt-get install git -y
+          git --version
+
   test_backend:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: '20.11'
+
       - name: Install Backend Dependencies
         run: |
           cd backend
           npm ci
+
       - name: Run Backend Tests with Coverage
         run: |
           cd backend
           npm test -- --coverage
+
+      - name: Upload Backend Coverage Report
+        uses: actions/upload-artifact@v3
+        with:
+          name: backend-coverage
+          path: backend/coverage/lcov.info
 
   test_frontend:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: '22.11'
+
       - name: Install Frontend Dependencies
         run: |
           cd frontend
           npm install
+
       - name: Run Frontend Tests with Coverage
         run: |
           cd frontend
           npm run test -- --coverage
+
+      - name: Upload Frontend Coverage Report
+        uses: actions/upload-artifact@v3
+        with:
+          name: frontend-coverage
+          path: frontend/coverage/lcov.info
 
   sonar_scan:
     runs-on: ubuntu-latest
@@ -59,7 +76,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Install Java (Required for SonarQube)
+      - name: Install Java (Required for SonarCloud)
         run: |
           sudo apt update
           sudo apt install -y openjdk-17-jdk
@@ -74,12 +91,27 @@ jobs:
           export PATH="/opt/sonar-scanner/bin:$PATH"
           sonar-scanner --version
 
-          - name: Run SonarQube Analysis
-          run: |
-            export PATH="/opt/sonar-scanner/bin:$PATH"
-            sonar-scanner \
-              -Dsonar.projectKey=SOEN390 \
-              -Dsonar.sources=. \
-              -Dsonar.host.url="${{ secrets.SONAR_HOST_URL }} || (echo "SonarQube failed URL" && exit 1)" \
-              -Dsonar.token="${{ secrets.SONAR_TOKEN }}" || (echo "SonarQube failed token" && exit 1)
-  
+      - name: Download Coverage Reports
+        uses: actions/download-artifact@v3
+        with:
+          name: backend-coverage
+          path: backend/coverage
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: frontend-coverage
+          path: frontend/coverage
+
+      - name: Run SonarCloud Analysis
+        run: |
+          export PATH="/opt/sonar-scanner/bin:$PATH"
+          sonar-scanner \
+            -Dsonar.organization=${{ secrets.SONAR_ORG }} \
+            -Dsonar.projectKey=SOEN390 \
+            -Dsonar.sources=. \
+            -Dsonar.host.url=${{ secrets.SONAR_HOST_URL }} \
+            -Dsonar.token=${{ secrets.SONAR_TOKEN }} \
+            -Dsonar.javascript.lcov.reportPaths=backend/coverage/lcov.info,frontend/coverage/lcov.info || (echo "SonarCloud analysis failed" && exit 1)
+
+      - name: Get SonarCloud Results
+        run: "echo 'Check SonarCloud Report: https://sonarcloud.io/dashboard?id=SOEN390&branch=${GITHUB_REF##*/}'"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,7 @@ jobs:
           export PATH="/opt/sonar-scanner/bin:$PATH"
           sonar-scanner \
             -Dsonar.organization=${{ secrets.SONAR_ORG }} \
-            -Dsonar.projectKey=SOEN-390 \
+            -Dsonar.projectKey=Andrew-Dagher_SOEN-390 \
             -Dsonar.sources=. \
             -Dsonar.host.url=${{ secrets.SONAR_HOST_URL }} \
             -Dsonar.token=${{ secrets.SONAR_TOKEN }} \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,14 +7,13 @@ permissions:
   pull-requests: write
 
 jobs:
-
   test_backend:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Backend Code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
+      - name: Setup Node.js for Backend
         uses: actions/setup-node@v3
         with:
           node-version: '20.11'
@@ -38,10 +37,10 @@ jobs:
   test_frontend:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Frontend Code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
+      - name: Setup Node.js for Frontend
         uses: actions/setup-node@v4
         with:
           node-version: '22.11'
@@ -66,8 +65,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test_backend, test_frontend]
     steps:
-      - name: Checkout Code
+      - name: Checkout Code with Full History
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Install Java (Required for SonarCloud)
         run: |
@@ -138,9 +139,8 @@ jobs:
             🔹 **Backend Coverage**: \`${{ env.BACKEND_COVERAGE }}%\`
             🔹 **Frontend Coverage**: \`${{ env.FRONTEND_COVERAGE }}%\`
 
-            _View full details in [SonarCloud Report](https://sonarcloud.io/dashboard?id=SOEN390&branch=${{ github.ref_name }})_
+            _View full details in [SonarCloud Report](https://sonarcloud.io/dashboard?id=Andrew-Dagher_SOEN-390&branch=${{ github.ref_name }})_
             `;
-
             github.rest.issues.createComment({
               issue_number: context.payload.pull_request.number,
               owner: context.repo.owner,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: Testing and Code Analysis
 
 on: [push, pull_request]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
 
   test_backend:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Git
         run: |
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '20.11'
 
@@ -37,7 +37,7 @@ jobs:
           npm test -- --coverage
 
       - name: Upload Backend Coverage Report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: backend-coverage
           path: backend/coverage/lcov.info
@@ -46,10 +46,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '22.11'
 
@@ -64,7 +64,7 @@ jobs:
           npm run test -- --coverage
 
       - name: Upload Frontend Coverage Report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4  # ✅ Updated to v4
         with:
           name: frontend-coverage
           path: frontend/coverage/lcov.info
@@ -74,7 +74,7 @@ jobs:
     needs: [test_backend, test_frontend]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Java (Required for SonarCloud)
         run: |
@@ -91,13 +91,14 @@ jobs:
           export PATH="/opt/sonar-scanner/bin:$PATH"
           sonar-scanner --version
 
-      - name: Download Coverage Reports
-        uses: actions/download-artifact@v2
+      - name: Download Backend Coverage Report
+        uses: actions/download-artifact@v4  # ✅ Updated to v4
         with:
           name: backend-coverage
           path: backend/coverage
 
-      - uses: actions/download-artifact@v2
+      - name: Download Frontend Coverage Report
+        uses: actions/download-artifact@v4  # ✅ Updated to v4
         with:
           name: frontend-coverage
           path: frontend/coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
               summary = fs.readFileSync(summaryPath, 'utf8');
             }
             const message = `
-            🚀 **Backend Code Coverage Report** 🚀
+            **Backend Code Coverage Report** 
 
             \`\`\`
             ${summary}
@@ -112,7 +112,7 @@ jobs:
               summary = fs.readFileSync(summaryPath, 'utf8');
             }
             const message = `
-            🚀 **Frontend Code Coverage Report** 🚀
+            **Frontend Code Coverage Report** 
 
             \`\`\`
             ${summary}


### PR DESCRIPTION
## User Story / Issue  
closes #116  

## Implementation  
add ```npm test -- --coverage``` for testing front and backend. Then adding SonarQube action to see the report each time you run the pipeline.

## Specific Review Request  
check to see if you can access the SonarQube report and see test coverage. 

