### PR TITLE
[Fix] Fixed Transparency Issue with MapCard Background 

### DIFF
--- a/frontend/app/components/navigation/MapCard.jsx
+++ b/frontend/app/components/navigation/MapCard.jsx
@@ -100,11 +100,13 @@ const MapCard = ({ building, isCallout = false }) => {
   return (
     <Pressable
       testID="mapcard-view"
-      style={({ pressed }) => [styles.shadow, pressed && { opacity: 0.7 }]}
+      style={({ pressed }) => [pressed && { opacity: 0.7 }]}
       onPress={handlePress}
       delayPressIn={isCallout ? 100 : 0}
     >
+    <View style={styles.shadow}>
       <CardContent buildingData={buildingData} />
+    </View>
     </Pressable>
   );
 };

--- a/frontend/app/components/navigation/MapCard.jsx
+++ b/frontend/app/components/navigation/MapCard.jsx
@@ -128,7 +128,7 @@ const styles = StyleSheet.create({
   shadow: {
     width: 250,
     backgroundColor: "white",
-    padding: 6,
+    padding: 10,
     borderRadius: 8,
     shadowColor: "#000",
     shadowOffset: { width: 0, height: 4 },


### PR DESCRIPTION
## User Story / Issue  
#190 - Transparency issue with Map Card Background

## Implementation  
Fixed map card transparency by moving the background styling from Pressable to an inner View container.


## Extra Info  
Before: 
![IMG_2728](https://github.com/user-attachments/assets/a7cb7359-205e-407b-9307-6444f73c63bb)

After:  
![IMG_2730](https://github.com/user-attachments/assets/af05e727-ce4e-4db9-b89c-a47002ee6dea)
